### PR TITLE
Refactored application: Moved generic functions to interface definitions

### DIFF
--- a/engine/engines.go
+++ b/engine/engines.go
@@ -12,41 +12,109 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Props : The scraping engine Properties and description about the engine (e.g NetNaijaEngine)
-type Props struct {
-	Name        string
-	BaseURL     *url.URL // The Base URL for the engine
-	SearchURL   *url.URL // URL for searching
-	ListURL     *url.URL // URL to return movie lists
-	Description string
-}
+// Mode : The mode of operation for scraping
+type Mode int
 
-// PropsJSON : JSON structure of all downloadable movies
-type PropsJSON struct {
-	Props
-	BaseURL   string
-	SearchURL string
-	ListURL   string
-}
+const (
+	// SearchMode : in this mode a query is searched for
+	SearchMode Mode = iota
+	// ListMode : in this mode a page is looked up
+	ListMode
+)
 
-// MarshalJSON Props structure to return from api
-func (p *Props) MarshalJSON() ([]byte, error) {
-	props := PropsJSON{
-		Props:     *p,
-		BaseURL:   p.BaseURL.String(),
-		SearchURL: p.SearchURL.String(),
-		ListURL:   p.ListURL.String(),
-	}
-
-	return json.Marshal(props)
+func (m Mode) String() string {
+	return [...]string{"Search", "List"}[m]
 }
 
 // Engine : interface for all engines
 type Engine interface {
+	getParseURL() *url.URL
 	Search(query string) SearchResult
-	Scrape(mode string) ([]Movie, error)
 	List(page int) SearchResult
 	String() string
+	// parseSingleMovie: parses the result of a colly HTMLElement and returns a movie
+	parseSingleMovie(el *colly.HTMLElement, index int) (Movie, error)
+
+	// getParseAttrs : get the attributes to use to parse a returned soup
+	// the first return string is the part of the html to be parsed e.g `body`, `main`
+	// the second return string is the attributes to be used in parsing the element specified
+	// by the first return
+	getParseAttrs() (string, string, error)
+
+	// parseSingleMovie: parses the result of a colly HTMLElement and returns a movie
+	updateDownloadProps(downloadCollector *colly.Collector, movies *[]Movie)
+}
+
+// Scrape : Parse queries a url and return results
+func Scrape(engine Engine) ([]Movie, error) {
+	c := colly.NewCollector(
+		// Cache responses to prevent multiple download of pages
+		// even if the collector is restarted
+		colly.CacheDir("./gophie_cache"),
+	)
+	// Another collector for download Links
+	downloadLinkCollector := c.Clone()
+
+	movieIndex := 0
+	var movies []Movie
+
+	// Any Extras setup for downloads using can be specified in the function
+	engine.updateDownloadProps(downloadLinkCollector, &movies)
+
+	main, article, err := engine.getParseAttrs()
+	if err != nil {
+		log.Fatal(err)
+	}
+	c.OnHTML(main, func(e *colly.HTMLElement) {
+		e.ForEach(article, func(_ int, el *colly.HTMLElement) {
+			movie, err := engine.parseSingleMovie(el, movieIndex)
+			if err != nil {
+				log.Errorf("%v could not be parsed", movie)
+			} else {
+				movies = append(movies, movie)
+				downloadLinkCollector.Visit(movie.DownloadLink.String())
+				movieIndex++
+			}
+		})
+	})
+
+	c.OnRequest(func(r *colly.Request) {
+		r.Headers.Set("Accept", "text/html")
+		log.Debugf("Visiting %v", r.URL.String())
+	})
+
+	c.OnResponse(func(r *colly.Response) {
+		log.Debugf("Done %v", r.Request.URL.String())
+	})
+
+	// Attach Movie Index to Context before making visits
+	// Adding Movie Index to context ensures we can fetch a reference to the
+	// movie details when we need it
+	downloadLinkCollector.OnRequest(func(r *colly.Request) {
+		r.Headers.Set("Accept", "text/html,application/xhtml+xml,application/xml")
+		for i, movie := range movies {
+			if movie.DownloadLink.String() == r.URL.String() {
+				log.Debugf("Retrieving Download Link %v\n", movie.DownloadLink)
+				r.Ctx.Put("movieIndex", strconv.Itoa(i))
+			}
+		}
+	})
+
+	// If Response Content Type is not Text, Abort the Request to prevent fully downloading the
+	// body in case of other types like mp4
+	downloadLinkCollector.OnResponseHeaders(func(r *colly.Response) {
+		if !strings.Contains(r.Headers.Get("Content-Type"), "text") {
+			r.Request.Abort()
+			log.Debugf("Response %s is not text/html. Aborting request", r.Request.URL)
+		}
+	})
+
+	downloadLinkCollector.OnResponse(func(r *colly.Response) {
+		movie := &movies[getMovieIndexFromCtx(r.Request)]
+		log.Debugf("Retrieved Download Link %v\n", movie.DownloadLink)
+	})
+	c.Visit(engine.getParseURL().String())
+	return movies, nil
 }
 
 // Movie : the structure of all downloadable movies

--- a/engine/fzmovies.go
+++ b/engine/fzmovies.go
@@ -54,102 +54,43 @@ func (engine *FzEngine) String() string {
 	return st
 }
 
-// Scrape : does the initial scraping, passed from List or Search
-func (engine *FzEngine) Scrape(mode string) ([]Movie, error) {
-	var (
-		url *url.URL
-	)
-	// When in search mode, results are in <article class="result">
-	switch mode {
-	case "search":
-		url = engine.SearchURL
-	case "list":
-		url = engine.ListURL
-	default:
-		return []Movie{}, fmt.Errorf("Invalid mode %v", mode)
+func (engine *FzEngine) getParseAttrs() (string, string, error) {
+	return "body", "div.mainbox", nil
+}
+
+func (engine *FzEngine) parseSingleMovie(el *colly.HTMLElement, index int) (Movie, error) {
+	movie := Movie{
+		Index:    index,
+		IsSeries: false,
+		Source:   engine.Name,
 	}
+	cover, err := url.Parse(el.Request.AbsoluteURL(el.ChildAttr("img", "src")))
+	if err != nil {
+		log.Fatal(err)
+	}
+	movie.CoverPhotoLink = cover.String()
+	// Remove all Video: or Movie: Prefixes
+	movie.UploadDate = strings.TrimSpace(el.ChildTexts("small")[1])
+	movie.Title = strings.TrimSuffix(strings.TrimSpace(el.ChildText("b")), "<more>")
+	movie.Description = strings.TrimSpace(el.ChildTexts("small")[3])
+	downloadLink, err := url.Parse(el.Request.AbsoluteURL(el.ChildAttr("a", "href")))
 
-	movieIndex := 0
-	c := colly.NewCollector(
-		// Cache responses to prevent multiple download of pages
-		// even if the collector is restarted
-		colly.CacheDir("./gophie_cache"),
-	)
-	// Another collector for download Links
-	downloadLinkCollector := c.Clone()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// download link is current link path + /download
+	downloadLink.Path = path.Join(engine.BaseURL.Path, downloadLink.Path)
 
-	var movies []Movie
+	movie.DownloadLink = downloadLink
+	return movie, nil
+}
 
-	c.OnHTML("body", func(e *colly.HTMLElement) {
-		e.ForEach("div.mainbox", func(_ int, el *colly.HTMLElement) {
-			movie := Movie{
-				Index:    movieIndex,
-				IsSeries: false,
-				Source:   engine.Name,
-			}
-			cover, _ := url.Parse(el.ChildAttr("img", "src"))
-			movie.CoverPhotoLink = cover.String()
-			// Remove all Video: or Movie: Prefixes
-			movie.UploadDate = strings.TrimSpace(el.ChildTexts("small")[1])
-			movie.Title = strings.TrimSuffix(strings.TrimSpace(el.ChildText("b")), "<more>")
-			movie.Description = strings.TrimSpace(el.ChildTexts("small")[3])
-			downloadLink, err := url.Parse(el.ChildAttr("a", "href"))
-
-			if err != nil {
-				log.Fatal(err)
-			}
-			// download link is current link path + /download
-			downloadLink.Path = path.Join(engine.BaseURL.Path, downloadLink.Path)
-
-			movie.DownloadLink = downloadLink
-			if movie.Title != "" {
-				movies = append(movies, movie)
-				downloadLinkCollector.Visit(movie.DownloadLink.String())
-				movieIndex++
-			}
-		})
-	})
-
-	c.OnRequest(func(r *colly.Request) {
-		r.Headers.Set("Accept", "text/html")
-		log.Debugf("Visiting %v", r.URL.String())
-	})
-
-	c.OnResponse(func(r *colly.Response) {
-		log.Debugf("Done %v", r.Request.URL.String())
-	})
-
-	// Attach Movie Index to Context before making visits
-	downloadLinkCollector.OnRequest(func(r *colly.Request) {
-		r.Headers.Set("Accept", "text/html,application/xhtml+xml,application/xml")
-		for i, movie := range movies {
-			if movie.DownloadLink.String() == r.URL.String() {
-				log.Debugf("Retrieving Download Link %v\n", movie.DownloadLink)
-				r.Ctx.Put("movieIndex", strconv.Itoa(i))
-			}
-		}
-	})
-
-	// If Response Content Type is not Text, Abort the Request to prevent fully downloading the
-	// body in case of other types like mp4
-	downloadLinkCollector.OnResponseHeaders(func(r *colly.Response) {
-		//    movie := &movies[getMovieIndexFromCtx(r.Request)]
-		if !strings.Contains(r.Headers.Get("Content-Type"), "text") {
-			r.Request.Abort()
-			log.Debugf("Response %s is not text/html. Aborting request", r.Request.URL)
-		}
-	})
-
-	downloadLinkCollector.OnResponse(func(r *colly.Response) {
-		movie := &movies[getMovieIndexFromCtx(r.Request)]
-		log.Debugf("Retrieved Download Link %v\n", movie.DownloadLink)
-	})
-
+func (engine *FzEngine) updateDownloadProps(downloadCollector *colly.Collector, movies *[]Movie) {
 	// Update movie download link if ul.downloadlinks on page
-	downloadLinkCollector.OnHTML("ul.moviesfiles", func(e *colly.HTMLElement) {
-		movie := &movies[getMovieIndexFromCtx(e.Request)]
+	downloadCollector.OnHTML("ul.moviesfiles", func(e *colly.HTMLElement) {
+		movie := &(*movies)[getMovieIndexFromCtx(e.Request)]
 		link := strings.Replace(e.ChildAttr("a", "href"), "download1.php", "download.php", 1)
-		downloadLink, err := url.Parse(link + "&pt=jRGarGzOo2")
+		downloadLink, err := url.Parse(e.Request.AbsoluteURL(link + "&pt=jRGarGzOo2"))
 		//    downloadLink, err := url.Parse(e.ChildAttr("a", "href") + "&pt=jRGarGzOo2")
 		if err != nil {
 			log.Fatal(err)
@@ -158,26 +99,24 @@ func (engine *FzEngine) Scrape(mode string) ([]Movie, error) {
 		re := regexp.MustCompile(`(.* MB)`)
 		dl := strings.TrimPrefix(re.FindStringSubmatch(e.ChildText("dcounter"))[0], "(")
 		movie.Size = dl
-		downloadLinkCollector.Visit(downloadLink.String())
+		downloadCollector.Visit(downloadLink.String())
 	})
 
 	// Update Download Link if "Download" HTML on page
-	downloadLinkCollector.OnHTML("p", func(e *colly.HTMLElement) {
+	downloadCollector.OnHTML("p", func(e *colly.HTMLElement) {
 		if strings.HasSuffix(strings.TrimSpace(e.ChildAttr("input", "value")), "mp4") {
-			downloadLink, err := url.Parse(e.ChildAttr("input", "value"))
+			downloadLink, err := url.Parse(e.Request.AbsoluteURL(e.ChildAttr("input", "value")))
 			if err != nil {
 				log.Fatal(err)
 			}
-			movies[getMovieIndexFromCtx(e.Request)].DownloadLink = downloadLink
+			(*movies)[getMovieIndexFromCtx(e.Request)].DownloadLink = downloadLink
 		}
 	})
-	c.Visit(url.String())
-
-	return movies, nil
 }
 
 // List : list all the movies on a page
 func (engine *FzEngine) List(page int) SearchResult {
+	engine.mode = ListMode
 	result := SearchResult{
 		Query: "List of Recent Uploads - Page " + strconv.Itoa(page),
 	}
@@ -186,7 +125,7 @@ func (engine *FzEngine) List(page int) SearchResult {
 	q.Set("by", "date")
 	q.Set("pg", strconv.Itoa(page))
 	engine.ListURL.RawQuery = q.Encode()
-	movies, err := engine.Scrape("list")
+	movies, err := Scrape(engine)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -196,13 +135,14 @@ func (engine *FzEngine) List(page int) SearchResult {
 
 // Search : Searches netnaija for a particular query and return an array of movies
 func (engine *FzEngine) Search(query string) SearchResult {
+	engine.mode = SearchMode
 	result := SearchResult{
 		Query: query,
 	}
 	q := engine.SearchURL.Query()
 	q.Set("searchname", query)
 	engine.SearchURL.RawQuery = q.Encode()
-	movies, err := engine.Scrape("search")
+	movies, err := Scrape(engine)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/engine/props.go
+++ b/engine/props.go
@@ -1,0 +1,47 @@
+package engine
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+// Props : The scraping engine Properties and description about the engine (e.g NetNaijaEngine)
+type Props struct {
+	// Engine Interface
+	Engine
+
+	// Struct attributes
+	Name        string
+	BaseURL     *url.URL // The Base URL for the engine
+	SearchURL   *url.URL // URL for searching
+	ListURL     *url.URL // URL to return movie lists
+	Description string
+	mode        Mode // The mode of the operations (list, search)
+}
+
+// PropsJSON : JSON structure of all downloadable movies
+type PropsJSON struct {
+	Props
+	BaseURL   string
+	SearchURL string
+	ListURL   string
+}
+
+// MarshalJSON Props structure to return from api
+func (p *Props) MarshalJSON() ([]byte, error) {
+	props := PropsJSON{
+		Props:     *p,
+		BaseURL:   p.BaseURL.String(),
+		SearchURL: p.SearchURL.String(),
+		ListURL:   p.ListURL.String(),
+	}
+
+	return json.Marshal(props)
+}
+
+func (p *Props) getParseURL() *url.URL {
+	if p.mode == SearchMode {
+		return p.SearchURL
+	}
+	return p.ListURL
+}


### PR DESCRIPTION
This PR should provide an easy to integrate new engines functionality. Each new engine struct must define the following methods only:

- `getParseAttrs`: this returns the attributes to be used to parse the return request pages for instance `div.main_block`
- `parseSingleMovie`: on parsing the request pages with the `getParseAttrs` function, this function is called with each movie soup defined by `getParseAttrs` and should return a movie instance
- `updateDownloadProps`: sometimes other setups would be made with download requests pages, this function allows for extending the inbuilt scrape function

Future modifications would involve abstracting away the `List` and `Search` function in the Engine definitions